### PR TITLE
Refactor DmaBuffer to use const generic length 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+grounded = "0.2.0"
 
 [dev-dependencies]
-grounded = "0.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,12 +26,7 @@
 //! #[unsafe(link_section = ".sram1_bss")]
 //! static BUFFER: GroundedArrayCell<u8, 1024> = GroundedArrayCell::uninit();
 //!
-//! let raw_buffer = unsafe {
-//!     BUFFER.initialize_all_copied(0);
-//!     let (ptr, len) = BUFFER.get_ptr_len();
-//!     core::slice::from_raw_parts_mut(ptr, len)
-//! };
-//! let dma_buffer = DmaBuffer::<u8, Sram1>::new(raw_buffer);
+//! let dma_buffer = DmaBuffer::<_, _, Sram1>::new(&BUFFER, 0);
 //! ```
 //!
 //! ## Regions

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ impl<T: Copy, const LEN: usize, Region: DmaAccessible> DmaBuffer<T, LEN, Region>
     /// (e.g., it could be a leaked heap allocation). It is just for rejecting local variable’s simple reference.
     /// For DMA safety, ensure the buffer is placed in a `static` variable.
     /// like:
-    /// ```rust,no-run
+    /// ```rust,no_run
     /// use dma_accessible::{DmaBuffer, Sram1};
     /// use grounded::uninit::GroundedArrayCell;
     ///


### PR DESCRIPTION
This pull request refactors the `DmaBuffer` type to use a const generic length and integrates the `GroundedArrayCell` type from the `grounded` crate for safer buffer initialization. The changes improve type safety, buffer region validation, and initialization patterns, making DMA buffer usage more robust and less error-prone.

**Buffer API and Type Refactor:**

* Refactored `DmaBuffer` to use a const generic length (`LEN`) instead of storing `len` as a field, improving compile-time safety and simplifying buffer management.
* Removed methods `len()` and `is_empty()` from `DmaBuffer`, as buffer length is now a compile-time constant.

**Integration of GroundedArrayCell:**

* Changed the buffer initialization to use `GroundedArrayCell` from the `grounded` crate, ensuring buffers are properly initialized and memory-safe for DMA operations. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L108-R140) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R49-R50) [[3]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R7-L9)
* Updated the test to use the new `DmaBuffer` API and `GroundedArrayCell`, demonstrating safer buffer creation and initialization.

**Address Range Validation:**

* Improved address range validation in `DmaBuffer::new`, now using the const generic length for more precise checks.